### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,7 +9,7 @@ Status
    :target: http://travis-ci.org/mkouhei/pydebsign
 .. image:: https://coveralls.io/repos/mkouhei/pydebsign/badge.png?branch=devel
    :target: https://coveralls.io/r/mkouhei/pydebsign?branch=devel
-.. image:: https://pypip.in/v/pydebsign/badge.png
+.. image:: https://img.shields.io/pypi/v/pydebsign.svg
    :target: https://crate.io/packages/pydebsign
 .. image:: https://readthedocs.org/projects/pydebsign/badge/?version=latest
    :target: https://readthedocs.org/projects/pydebsign/?badge=latest


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20pydebsign))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `pydebsign`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.